### PR TITLE
Fix concurrency issue and update node engine

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
     'gatsby-plugin-mdx',
     {
       resolve: 'gatsby-plugin-react-svg',
-      ptions: {
+      options: {
         rule: {
           include: /svg/,
         },
@@ -28,6 +28,7 @@ module.exports = {
         buildMarkdownNodes: true,
         downloadLocalImages: true,
         fragmentsPath: 'hygraph-fragments',
+        queryConcurrency: 1
       },
     },
     'gatsby-transformer-sharp',

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "clean": "gatsby clean",
     "dev": "gatsby develop"
   },
+  "engines": {
+    "node": "~16"
+  },
   "dependencies": {
     "@mdx-js/mdx": "1.6.18",
     "@mdx-js/react": "1.6.18",


### PR DESCRIPTION
This starter was being hit by rate limiting errors. This PR fixes the following issues:

* Sets concurrency to 1 to fix rate limit
* Fixes typo in Gatsby-plugin-mdx
* Forces Vercel to use Node 16 to fix dependency issue with node 18